### PR TITLE
With moment().format() unified date format

### DIFF
--- a/Sources/SwiftMoment/Moment.swift
+++ b/Sources/SwiftMoment/Moment.swift
@@ -47,7 +47,7 @@ public func moment(_ stringDate: String,
     let formatter = DateFormatter()
     formatter.timeZone = timeZone
     formatter.locale = locale
-    let isoFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
+    let isoFormat = "yyyy-MM-dd HH:mm:ss ZZZZ"
 
     // The contents of the array below are borrowed
     // and adapted from the source code of Moment.js


### PR DESCRIPTION
var create_at: String = moment().format()   

No uniform date format
moment(create_at)   // Is nil
moment(create_at, dateFormat: "yyyy-MM-dd HH:mm:ss ZZZZ", timeZone: .current, locale: .current)

Unified date format
moment(create_at)   // not nil