### PR TITLE
Added version 4.0 tag in Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,6 @@
 // Generated automatically by Perfect Assistant Application
 // Date: 2017-10-10 14:00:01 +0000
+// swift-tools-version:4.0
 import PackageDescription
 let package = Package(
 	name: "SwiftMoment",


### PR DESCRIPTION
Hi,

we added 

// swift-tools-version:4.0 

entry  in Package.swift for Swift 4.0 compatibility.

 Furthermore, we would like to ask to add a 4.0.0 tag to reference this version.